### PR TITLE
Bump torchlight-laravel version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.6.0 - 2022-02-23
+
+### Changed
+
+- Updated torchlight-laravel version constraint
+
 ## 0.5.5 - 2022-02-23
 
 ### Changed
@@ -50,7 +56,6 @@
 - Bump `torchlight/torchlight-laravel` dependency.
 - Use `Torchlight::highlight` instead of `(new Client)->highlight`
 
-
 ## 0.3.3 - 2021-07-31
 
 ### Changed
@@ -80,7 +85,6 @@
 
 - Bump `torchlight/torchlight-laravel` dependency.
 - Changed package name from `torchlight/commonmark` to `torchlight/torchlight-commonmark`
-
 
 ## 0.1.0
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "torchlight/torchlight-laravel": "^0.5.10",
+        "torchlight/torchlight-laravel": "^0.6.0",
         "league/commonmark": "^1.5|^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Update the version of `torchlight/torchlight-laravel` to `^0.6.0` in `composer.json`.

* **composer.json**
  - Change the version constraint for `torchlight/torchlight-laravel` from `^0.5.10` to `^0.6.0`.

* **CHANGELOG.md**
  - Add an entry for version `0.6.0` under the "Unreleased" section.
  - Mention the update of `torchlight-laravel` version constraint.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CamKem/torchlight-commonmark-php/pull/1?shareId=a486685b-5fcd-4e75-bdb6-c4b6215aed0c).